### PR TITLE
More touch support

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -179,11 +179,15 @@
     	    textInput.change(setFromTextInput);
     	    textInput.keydown(function(e) { if (e.keyCode == 13) { setFromTextInput(); } } );
 
-            cancelButton.click(function() {
+            cancelButton.bind("click touchstart", function(e) {
+                e.stopPropagation();
+                e.preventDefault();
                 cancel();
                 hide();
             });
-            chooseButton.click(function() {
+            chooseButton.bind("click touchstart", function(e) {
+                e.stopPropagation();
+                e.preventDefault();
                 hide();
             });
     	    draggable(slider, function(dragX, dragY) {
@@ -210,8 +214,9 @@
         	    show();
         	}
         	
-        	palletContainer.delegate("span", "click", function() {
-        		set($(this).css("background-color"));
+        	palletContainer.delegate("span", "click touchstart", function(e) {
+                set($(this).css("background-color"));
+                e.stopPropagation();
         	});
 		}
 		


### PR DESCRIPTION
Hi Brian,

I took the liberty of adding a few more missing touch events to your wonderful colorpicker. With this update it fully works on (at least) my iPad. I hope you find this tiny extension useful.

Commit message:
Added touch event to pallet colors. Added touch events to cancel and choose buttons and prevention from elements in the back receiving those touch events too.

Cheers, 

Pascal Lindelauf
