### PR TITLE
Only revert on hide when the buttons are shown

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -401,11 +401,13 @@
             replacer.removeClass("sp-active");
             container.hide();
 
-            var colorHasChanged = !tinycolor.equals(get(), colorOnShow);
+            if (opts.showButtons) {
+                var colorHasChanged = !tinycolor.equals(get(), colorOnShow);
 
-            // Change hasn't been called yet, so call it now that the picker has closed
-            if (colorHasChanged) {
-                revert();
+                // Change hasn't been called yet, so call it now that the picker has closed
+                if (colorHasChanged) {
+                    revert();
+                }
             }
 
             callbacks.hide(get());


### PR DESCRIPTION
With `showButtons` disabled there is no way the user can save the input. Is this the right way to only revert the changes when the buttons were visible?

Steps to reproduce:
- Start with a color input and `{ showButtons: false }`
- Click on the input. The widget is shown.
- Change the color.
- How to save? Click next to the input. The color is reverted.
