### PR TITLE
Added method to retrieve color picker's spectrum dialog container.

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -732,7 +732,7 @@
         if (typeof opts == "string") {
             if (opts == "get") {
                 return spectrums[this.eq(0).data(dataID)].get();
-            } else if (opts == "getSpect") {
+            } else if (opts == "container") {
                 return spectrums[$(this).data(dataID)].container;
             }
 


### PR DESCRIPTION
Useful if we need to attach events or manually position the Spectrum dialog.

For example, to get the container, we could call:
    $("#myColorPicker").spectrum("container")
