### PR TITLE
Touch on polyfill does not choose color

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -780,9 +780,7 @@
                     $(doc).bind(duringDragEvents);
                     $(doc.body).addClass("sp-dragging");
 
-                    if (!hasTouch) {
-                        move(e);
-                    }
+                    move(e);
 
                     prevent(e);
                 }


### PR DESCRIPTION
On my Android phone I noticed, that I can't just click (resp. touch) on the polyfill, I have to click and drag (tested in Chrome for Android and Mozilla Firefox, most current versions). I thought that this problem can't be that difficult to fix and in fact it just took me a couple of minutes to find the bug.

I don't know why you should want "if(!hasTouch)", it doesn't make sense to me.

Thanks for your nice color picker!

greetings,
plepe
