### PR TITLE
Removing unnecessary UTF BOM character from beginning of CSS file  

### DIFF
--- a/spectrum.css
+++ b/spectrum.css
@@ -1,4 +1,4 @@
-﻿/***
+/***
 Spectrum Colorpicker v1.0.2
 https://github.com/bgrins/spectrum
 Author: Brian Grinstead


### PR DESCRIPTION
Hi,

After merging spectrum.css with other CSS files, we've invalid unicode (U-FEFF, zero width non-breaking space) character inside merged file (which is at the beginning of original file). 

When browser (e.g. Chrome) fetch merged file with strange character, styles from this file aren't applied properly.

After removing few bytes from file's beginning everything went back to normal.   
