### PR TITLE
rgba support for selectionPalette

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -108,7 +108,7 @@
             c += (tinycolor.equals(color, p[i])) ? " sp-thumb-active" : "";
 
             var swatchStyle = rgbaSupport ? ("background-color:" + tiny.toRgbString()) : "filter:" + tiny.toFilter();
-            html.push('<span title="' + tiny.toHexString() + '" data-color="' + tiny.toRgbString() + '" class="' + c + '"><span class="sp-thumb-inner" style="' + swatchStyle + ';" /></span>');
+            html.push('<span title="' + tiny.toRgbString() + '" data-color="' + tiny.toRgbString() + '" class="' + c + '"><span class="sp-thumb-inner" style="' + swatchStyle + ';" /></span>');
         }
         return "<div class='sp-cf " + className + "'>" + html.join('') + "</div>";
     }


### PR DESCRIPTION
I strongly need the support of alphatransparency, so I was very happy to discover spectrum.
However, the selected colors are currently stored in a hex format, which lacks the alphachannel.

I changed the colorformat in the color palette from hex to rgb, so that selected colors with alphatransparency will be saved correctly.
