### PR TITLE
Issue102 datalist

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -440,12 +440,11 @@
         function updateDatalistPalette() {
             var listID = $(element).attr('list');
             if(listID) {
-                datalistPalette = $('#'+listID).first().filter('datalist').find('option:not(:disabled)')
-                                        .toArray().map(function(opt) {
-                                            return $(opt).val();
-                                        }).filter(function(opt) {
-                                            return opt !== '';
-                                        });
+                datalistPalette = $("datalist#" + listID).find("option").filter(function() {
+                  return !$(this).is(":disabled") && $.trim(this.value) !== "";
+                }).map(function() {
+                  return this.value;
+                }).toArray();
             } else {
                 datalistPalette = [];
             }


### PR DESCRIPTION
Tried to fix this on my own:

Added new option showDatalistPalette, that defaults to true.
If a (valid) datalist is present, its values are used to form a palette, that is shown above any other palette (i.e. palette and selectionPalette).

The new datalistPalette is initially empty and update, when the UI is updated. This is to respect changes of the datalist element/list attribute. (This causes "flat" colorpickers to "jump".)

Uniqueness of selectionPalette colors are checked against datalistPalette colors, if applicable.

Created some tests:
http://jsfiddle.net/5M2Z6/
