### PR TITLE
Turkish translation is added

### DIFF
--- a/i18n/jquery.spectrum-tr.js
+++ b/i18n/jquery.spectrum-tr.js
@@ -1,5 +1,5 @@
 // Spectrum Colorpicker
-// Italian (it) localization
+// Turkish (tr) localization
 // https://github.com/bgrins/spectrum
 
 (function ( $ ) {


### PR DESCRIPTION
I have translated the word "Choose" to "Okay". Because it feels a little weird to see the word choose there. At least to me it feels like google translate :)

the word "choose" is "seç"
and the word "okay" is "tamam"

If you feel like this detail somehow breaks the consistency, you can always reject this pull request.
