### PR TITLE
google closure compatibility fix

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -1881,7 +1881,7 @@
 
         root.tinycolor = tinycolor;
 
-    })(this);
+    })(window);
 
     $(function () {
         if ($.fn.spectrum.load) {


### PR DESCRIPTION
When minified with google closure, the line: `root.tinycolor = tinycolor` results in an error, because root is undefined. 

This is related to strict mode because putting `"use strict";` at the top gives the same error. 

Using `window` explicitely fixes the issue.
