### PR TITLE
Adding additional closeOnSelect option that allows a simple and fast way...

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -34,8 +34,7 @@
         theme: "sp-light",
         palette: ['fff', '000'],
         selectionPalette: [],
-        disabled: false,
-        closeOnSelect: false
+        disabled: false
     },
     spectrums = [],
     IE = !!/msie/i.exec( window.navigator.userAgent ),
@@ -341,7 +340,7 @@
 
                 move();
 
-            }, dragStart, opts.closeOnSelect ? dragStopAndClose : dragStop);
+            }, dragStart, dragStop);
 
             if (!!initialColor) {
                 set(initialColor);
@@ -463,12 +462,6 @@
             container.removeClass(draggingClass);
         }
 
-        function dragStopAndClose() {
-            container.removeClass(draggingClass);
-            updateOriginalInput(true);
-            hide();
-        }
-
         function setFromTextInput() {
             var tiny = tinycolor(textInput.val());
             if (tiny.ok) {
@@ -521,6 +514,14 @@
             drawInitial();
             callbacks.show(colorOnShow);
             boundElement.trigger('show.spectrum', [ colorOnShow ]);
+
+            // listen for enter key events
+            $(doc).bind("keydown", function (e) {
+                if(e.which == 13) {
+                    updateOriginalInput(true);
+                    hide();
+                }
+            });
         }
 
         function hide(e) {
@@ -532,6 +533,7 @@
             if (!visible || flat) { return; }
             visible = false;
 
+            $(doc).unbind("keydown");
             $(doc).unbind("click.spectrum", hide);
             $(window).unbind("resize.spectrum", resize);
 


### PR DESCRIPTION
Hi there,

I've added a new default param to spectrum, closeOnSelect. After using spectrum for a while now, I found using the choose button was a tad clunky when I wanted to select a color quickly, or select multiple colors. That was the reasoning behind this new addition. I only added this functionality to the main color selection area, rather than the slider - as I see this as a refine. Tests run fine with the changes. Let me know what you think anyway.

Thanks for bringing spectrum to life :dancers: 
- ottis
