### PR TITLE
Update spectrum.css

### DIFF
--- a/spectrum.css
+++ b/spectrum.css
@@ -364,6 +364,9 @@ See http://bgrins.github.io/spectrum/themes/ for instructions.
     margin-right: 5px;
     float:left;
     z-index: 0;
+    /* force background images and colors */
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
 }
 
 .sp-palette


### PR DESCRIPTION
If the user is printing from a WebKit browser (Google’s Chrome or Apple’s Safari), we can force the printer to render the colors as seen on screen (i.e. force any background images and colors to appear on the printed page).

example:

@media print and (color) {
- {
    -webkit-print-color-adjust: exact;
    print-color-adjust: exact;
  }
  }
