### PR TITLE
check localStorage during drawPalette() to sync palettes

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -435,6 +435,17 @@
                 return paletteTemplate(palette, currentColor, "sp-palette-row sp-palette-row-" + i);
             });
 
+            // Load from local storage
+            // When there are multiple color pickers,
+            // the saved custom colors can be synchronized without refreshing the page
+            if(localStorageKey && window.localStorage){
+                try{
+                    var oldPalette = window.localStorage[localStorageKey];
+                    selectionPalette = oldPalette.split(';');
+                }
+                catch(e){}
+            }
+
             if (selectionPalette) {
                 html.push(paletteTemplate(getUniqueSelectionPalette(), currentColor, "sp-palette-row sp-palette-row-selection"));
             }


### PR DESCRIPTION
I made changes in drawPalette() to always check for the latest palette in localStorage. 
So, when there are multiple color pickers, the saved custom colors can be synchronized without refreshing the page. 
