### PR TITLE
Set currentAlpha to 1 if showAlpha is off when dragging in slider or dragger

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -349,6 +349,9 @@
             draggable(slider, function (dragX, dragY) {
                 currentHue = parseFloat(dragY / slideHeight);
                 isEmpty = false;
+                if (!opts.showAlpha) {
+                    currentAlpha = 1;
+                }
                 move();
             }, dragStart, dragStop);
 
@@ -377,6 +380,9 @@
                 }
 
                 isEmpty = false;
+                if (!opts.showAlpha) {
+                    currentAlpha = 1;
+                }
 
                 move();
 
@@ -661,7 +667,7 @@
 
             // Get a format that alpha will be included in (hex and names ignore alpha)
             var format = currentPreferredFormat;
-            if (currentAlpha < 1) {
+            if (currentAlpha < 1 && !(currentAlpha === 0 && format === "name")) {
                 if (format === "hex" || format === "hex3" || format === "hex6" || format === "name") {
                     format = "rgb";
                 }


### PR DESCRIPTION
This handles the case where I want to support hex colors + "transparent".

Spectrum handles setting the value to "transparent" fine, but then there's no way to change the alpha back to 1 with the alpha slider disabled. This will set the currentAlpha to 1 if you drag on the slider/dragger and the alpha slider is disabled.
