### PR TITLE
Refresh color palette from localStorage on each open

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -444,8 +444,6 @@
         }
 
         function getUniqueSelectionPalette() {
-            updateSelectionPalette()
-
             var unique = [];
             var p = selectionPalette;
             var paletteLookup = {};
@@ -538,6 +536,7 @@
             var event = $.Event('beforeShow.spectrum');
 
             if (visible) {
+                updateSelectionPalette();
                 reflow();
                 return;
             }
@@ -559,6 +558,7 @@
             if (opts.showPalette) {
                 drawPalette();
             }
+            updateSelectionPalette();
             reflow();
             updateUI();
 


### PR DESCRIPTION
Refresh color palette from localStorage on each open instead of only the first init.
Useful when you have multiple spectrum instances initialized at the same time, and selecting a color in one of them should also update the other's palette.
