### PR TITLE
fix validation problem

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -523,6 +523,7 @@
             else {
                 var tiny = tinycolor(value);
                 if (tiny.ok) {
+                    textInput.removeClass("sp-validation-error");
                     set(tiny);
                 }
                 else {


### PR DESCRIPTION
Empty color value and cause validation error then set the
same color value again will not clear the validation error.
