### PR TITLE
AMD and specified positioning

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -37,6 +37,7 @@
                 theme: "sp-light",
                 palette: ['fff', '000'],
                 selectionPalette: [],
+                positioning: 'absolute',
                 disabled: false
             },
             spectrums = [],
@@ -817,7 +818,7 @@
                     alphaSlideHelperWidth = alphaSlideHelper.width();
 
                     if (!flat) {
-                        container.css("position", "absolute");
+                        container.css("position", opts.positioning);
                         if( typeof opts.position === 'object' ) {
                             container.offset(opts.position);
                         } else {


### PR DESCRIPTION
I had a need for AMD loading and explicit positioning on a project I am working on and didn't see support for those in spectrum. I added those features and thought you might want these changes. The AMD loading is optional, if you use the script normally it will use the global namespace as it did before, if loading via requirejs it will use the require() method instead.

As for the positioning, it can be supplied in the options via:
$('#element').spectrum({ position: { top: 100, left: 200 } });

... or updated afterwards via a method:
$('#element').spectrum("position", { left: 10, top: 20 });

Let me know if these changes look ok, or if you would like something altered in order to integrate them.
