### PR TITLE
Update selectedPalette in all other instances also on open

### DIFF
--- a/docs/docs.js
+++ b/docs/docs.js
@@ -302,8 +302,8 @@ $(".override").spectrum({
     change: updateBorders
 });
 
-$(".startEmpty").spectrum({ 
-    allowEmpty:true, 
+$(".startEmpty").spectrum({
+    allowEmpty:true,
     change: updateBorders});
 
 $("#beforeShow").spectrum({
@@ -330,6 +330,12 @@ $("#showSelectionPalette").spectrum({
     palette: [ ]
 });
 $("#showSelectionPaletteStorage").spectrum({
+    showPalette: true,
+    localStorageKey: "spectrum.homepage", // Any picker with the same string will share selection
+    showSelectionPalette: true,
+    palette: [ ]
+});
+$("#showSelectionPaletteStorage2").spectrum({
     showPalette: true,
     localStorageKey: "spectrum.homepage", // Any picker with the same string will share selection
     showSelectionPalette: true,
@@ -371,7 +377,6 @@ $("#triggerSet").show();
 $("#btnEnterAColor").click(function() {
     $("#triggerSet").spectrum("set", $("#enterAColor").val());
 });
-
 
 $("#toggle").spectrum();
 $("#btn-toggle").click(function() {

--- a/index.html
+++ b/index.html
@@ -384,8 +384,9 @@ $("#showSelectionPaletteStorage").spectrum({
             <div class='example'>
                     <span class='label label-info'>This colorpicker will store what you pick:</span><br /><br />
                     <input type='text' name='showSelectionPalette' id='showSelectionPalette' value='lightblue' /><br /><br />
-                    <span class='label label-info'>Try reloading your page, it will still be here on this one:</span><br /><br />
+                    <span class='label label-info'>Try switching between the two colorpickers or reloading your page, the chosen colors are always available:</span><br /><br />
                     <input type='text' name='showSelectionPaletteStorage' id='showSelectionPaletteStorage' value='lightblue' />
+                    <input type='text' name='showSelectionPaletteStorage2' id='showSelectionPaletteStorage2' value='pink' />
             </div>
         </div>
 
@@ -460,7 +461,7 @@ $("#showInputInitialClear").spectrum({
     showInput: true
 });
             </pre>
-            
+
             <div class='example'>
                     <input type='text' name='showInputInitialClear' id='showInputInitialClear' value='' />
             </div>

--- a/spectrum.js
+++ b/spectrum.js
@@ -263,25 +263,7 @@
                 appendTo.append(container);
             }
 
-            if (localStorageKey && window.localStorage) {
-
-                // Migrate old palettes over to new format.  May want to remove this eventually.
-                try {
-                    var oldPalette = window.localStorage[localStorageKey].split(",#");
-                    if (oldPalette.length > 1) {
-                        delete window.localStorage[localStorageKey];
-                        $.each(oldPalette, function(i, c) {
-                             addColorToSelectionPalette(c);
-                        });
-                    }
-                }
-                catch(e) { }
-
-                try {
-                    selectionPalette = window.localStorage[localStorageKey].split(";");
-                }
-                catch (e) { }
-            }
+            updateSelectionPaletteFromStorage();
 
             offsetElement.bind("click.spectrum touchstart.spectrum", function (e) {
                 if (!disabled) {
@@ -430,6 +412,29 @@
             initialColorContainer.delegate(".sp-thumb-el:nth-child(1)", paletteEvent, { ignore: true }, palletElementClick);
         }
 
+        function updateSelectionPaletteFromStorage() {
+
+            if (localStorageKey && window.localStorage) {
+
+                // Migrate old palettes over to new format.  May want to remove this eventually.
+                try {
+                    var oldPalette = window.localStorage[localStorageKey].split(",#");
+                    if (oldPalette.length > 1) {
+                        delete window.localStorage[localStorageKey];
+                        $.each(oldPalette, function(i, c) {
+                             addColorToSelectionPalette(c);
+                        });
+                    }
+                }
+                catch(e) { }
+
+                try {
+                    selectionPalette = window.localStorage[localStorageKey].split(";");
+                }
+                catch (e) { }
+            }
+        }
+
         function addColorToSelectionPalette(color) {
             if (showSelectionPalette) {
                 var colorRgb = tinycolor(color).toRgbString();
@@ -484,6 +489,8 @@
             var html = $.map(paletteArray, function (palette, i) {
                 return paletteTemplate(palette, currentColor, "sp-palette-row sp-palette-row-" + i);
             });
+
+            updateSelectionPaletteFromStorage();
 
             if (selectionPalette) {
                 html.push(paletteTemplate(getUniqueSelectionPalette(), currentColor, "sp-palette-row sp-palette-row-selection"));

--- a/test/tests.js
+++ b/test/tests.js
@@ -367,3 +367,54 @@ test( "Change events fire as described" , function() {
   input.spectrum("set", "orange");
 
 });
+
+test("The selectedPalette should be updated in each spectrum instance, when storageKeys are identical.", function () {
+
+  delete window.localStorage["spectrum.tests"];
+
+  var colorToChoose = "rgb(0, 244, 0)";
+  var firstEl = $("<input id='firstEl' value='red' />").spectrum({
+    showPalette: true,
+    localStorageKey: "spectrum.tests"
+  });
+    var secondEl = $("<input id='secondEl' value='blue' />").spectrum({
+    showPalette: true,
+    localStorageKey: "spectrum.tests"
+  });
+
+  firstEl.spectrum("set", colorToChoose);
+
+  secondEl.spectrum("toggle");
+
+  var selectedColor = secondEl.spectrum("container").find('span[data-color="' + colorToChoose + '"]');
+  ok(selectedColor.length > 0, "Selected color is also shown in the others instance's palette.");
+
+  firstEl.spectrum("destroy");
+  secondEl.spectrum("destroy");
+});
+
+test("The selectedPalette should not be updated in spectrum instances, that have different storageKeys.", function () {
+
+  delete window.localStorage["spectrum.test_1"];
+  delete window.localStorage["spectrum.test_2"];
+
+  var colorToChoose = "rgb(0, 244, 0)";
+  var firstEl = $("<input id='firstEl' value='red' />").spectrum({
+    showPalette: true,
+    localStorageKey: "spectrum.test_1"
+  });
+    var secondEl = $("<input id='secondEl' value='blue' />").spectrum({
+    showPalette: true,
+    localStorageKey: "spectrum.test_2"
+  });
+
+  firstEl.spectrum("set", colorToChoose);
+
+  secondEl.spectrum("toggle");
+
+  var selectedColor = secondEl.spectrum("container").find('span[data-color="' + colorToChoose + '"]');
+  ok(selectedColor.length === 0, "Selected color should not be available in instances with other storageKey.");
+
+  firstEl.spectrum("destroy");
+  secondEl.spectrum("destroy");
+});


### PR DESCRIPTION
The spectrum colorpicker has already the option 'localStorageKey'. After reloading the page all instances with the same storageKey update their palettes with the chosen colors.

With my changes, the palettes gets updated also on open. That means, when there are more than one spectrum instance with the same storageKey and the user chooses a color in the first picker, he will see his selection immediately in the other picker after he has opened it.

Since the instances already get updated after a reload, this changes are a logical consequence for a multiple instance usage.

The changes are covered with two new tests.

I would be happy, I you could merge my request! I am looking forward for your feedback!
