### PR TITLE
harden tinycolor.equals

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -1537,7 +1537,12 @@
     // Can be called with any tinycolor input
     tinycolor.equals = function (color1, color2) {
         if (!color1 || !color2) { return false; }
-        return tinycolor(color1).toRgbString() == tinycolor(color2).toRgbString();
+        var tcolor1 = tinycolor(color1);
+        var tcolor2 = tinycolor(color2);
+        if (typeof tcolor1.toRgbString !== 'function' || typeof tcolor2.toRgbString !== 'function') {
+            return false;
+        }
+        return tcolor1.toRgbString() == tcolor2.toRgbString();
     };
     tinycolor.random = function() {
         return tinycolor.fromRatio({


### PR DESCRIPTION
In rare cases a stale version of a `tinycolor` gets passed to the `.equals` method, which causes a TypeError (`TypeError: Object #<Object> has no method 'toRgbString'`).
This is because even though a passed in color (e.g. stale JSON variant) qualifies for `typeof color == "object" && color.hasOwnProperty("_tc_id")` although it does not have the according `.toRgbString`.
