### PR TITLE
Add individual className options for replacer and container

### DIFF
--- a/docs/docs.js
+++ b/docs/docs.js
@@ -201,6 +201,14 @@ $("#className").spectrum({
     className: 'awesome'
 });
 
+$("#replacerClassName").spectrum({
+    replacerClassName: 'awesome'
+});
+
+$("#containerClassName").spectrum({
+    containerClassName: 'awesome'
+});
+
 $("#showPalette").spectrum({
     showPalette: true,
     palette: [

--- a/index.html
+++ b/index.html
@@ -534,6 +534,64 @@ $("#className").spectrum({
             </div>
         </div>
 
+        <h3 id="options-containerClassName">containerClassName</h3>
+        <div class='option-content'>
+            <div class='description'>
+                <p>
+                You can add an additional class name to the just the container element using the <code>containerClassName</code> property.
+                </p>
+            </div>
+
+            <pre class='prettyprint'>
+$("#containerClassName").spectrum({
+    containerClassName: 'awesome'
+});
+            </pre>
+            <pre class='prettyprint'>
+.awesome {
+    background: purple;
+}
+            </pre>
+            <style type='text/css'>
+.awesome {
+    background: purple;
+}
+            </style>
+
+            <div class='example'>
+                    <input type='text' name='containerClassName' id='containerClassName' value='orangered' />
+            </div>
+        </div>
+
+        <h3 id="options-replacerClassName">replacerClassName</h3>
+        <div class='option-content'>
+            <div class='description'>
+                <p>
+                You can add an additional class name to just the replacer element using the <code>replacerClassName</code> property.
+                </p>
+            </div>
+
+            <pre class='prettyprint'>
+$("#replacerClassName").spectrum({
+    replacerClassName: 'awesome'
+});
+            </pre>
+            <pre class='prettyprint'>
+.awesome {
+    background: purple;
+}
+            </pre>
+            <style type='text/css'>
+.awesome {
+    background: purple;
+}
+            </style>
+
+            <div class='example'>
+                    <input type='text' name='replacerClassName' id='replacerClassName' value='orangered' />
+            </div>
+        </div>
+
         <h3 id="options-preferredFormat">Preferred Format</h3>
         <div class='option-content'>
             <div class='description'>

--- a/spectrum.js
+++ b/spectrum.js
@@ -32,6 +32,8 @@
         clearText: "Clear Color Selection",
         preferredFormat: false,
         className: "",
+        containerClassName: "",
+        replacerClassName: "",
         showAlpha: false,
         theme: "sp-light",
         palette: [["#ffffff", "#000000", "#ff0000", "#ff8000", "#ffff00", "#008000", "#0000ff", "#4b0082", "#9400d3"]],
@@ -200,7 +202,7 @@
             isInput = boundElement.is("input"),
             isInputTypeColor = isInput && inputTypeColorSupport && boundElement.attr("type") === "color",
             shouldReplace = isInput && !flat,
-            replacer = (shouldReplace) ? $(replaceInput).addClass(theme).addClass(opts.className) : $([]),
+            replacer = (shouldReplace) ? $(replaceInput).addClass(theme).addClass(opts.className).addClass(opts.replacerClassName) : $([]),
             offsetElement = (shouldReplace) ? replacer : boundElement,
             previewElement = replacer.find(".sp-preview-inner"),
             initialColor = opts.color || (isInput && boundElement.val()),
@@ -237,7 +239,7 @@
             container.toggleClass("sp-palette-disabled", !opts.showPalette);
             container.toggleClass("sp-palette-only", opts.showPaletteOnly);
             container.toggleClass("sp-initial-disabled", !opts.showInitial);
-            container.addClass(opts.className);
+            container.addClass(opts.className).addClass(opts.containerClassName);
 
             reflow();
         }


### PR DESCRIPTION
This lets you do things like get (basic) Bootstrap stylings for free
using:

```
{
  replacerClassName: 'btn btn-default',
  containerClassName: 'dropdown-menu'
}
```

Though you'll need to add a little override to make that particular mix
work:

```
.sp-container.dropdown-menu {
  display: block;
}
```
