### PR TITLE
Add 'var' in getUniqueSelectionPalette function

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -467,7 +467,7 @@
         function getUniqueSelectionPalette() {
             var unique = [];
             if (opts.showPalette) {
-                for (i = 0; i < selectionPalette.length; i++) {
+                for (var i = 0; i < selectionPalette.length; i++) {
                     var rgb = tinycolor(selectionPalette[i]).toRgbString();
 
                     if (!paletteLookup[rgb]) {


### PR DESCRIPTION
'var' keyword was missing for variable 'i' in getUniqueSelectionPalette function.
