### PR TITLE
Add alwaysFireChange option

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -44,7 +44,8 @@
         theme: "sp-light",
         palette: [["#ffffff", "#000000", "#ff0000", "#ff8000", "#ffff00", "#008000", "#0000ff", "#4b0082", "#9400d3"]],
         selectionPalette: [],
-        disabled: false
+        disabled: false,
+        alwaysFireChange: false
     },
     spectrums = [],
     IE = !!/msie/i.exec( window.navigator.userAgent ),
@@ -842,7 +843,7 @@
 
             colorOnShow = color;
 
-            if (fireCallback && hasChanged) {
+            if ((fireCallback && hasChanged) || opts.alwaysFireChange) {
                 callbacks.change(color);
                 boundElement.trigger('change', [ color ]);
             }

--- a/test/tests.js
+++ b/test/tests.js
@@ -495,6 +495,27 @@ test( "Change events fire as described" , function() {
 
 });
 
+test( "Change events fire if option was set" , function() {
+
+  expect(2);
+  var input = $("<input />");
+
+  input.on("change", function() {
+    ok(true, "Change should be fired");
+  });
+
+  input.spectrum({
+    color: "red",
+    alwaysFireChange: true,
+    change: function() {
+      ok (true, "Change should be fired inside of spectrum callback");
+    }
+  });
+
+  input.spectrum("set", "orange");
+
+});
+
 test("The selectedPalette should be updated in each spectrum instance, when storageKeys are identical.", function () {
 
   delete window.localStorage["spectrum.tests"];


### PR DESCRIPTION
Given I am using the picker for text, and my text has mutliple
colors (green, yellow). Then I am initializing the colorpicker with
the color that makes the majority of the text (green).

When I want to change the whole textcolor to green, which is
realized by the change-callback, it would not fire, because the
color green was choosen before as it was the major color.

This commit adds an option which will cause the event to fire
on every click.

Example text, that I woould like to color yellow:

![bildschirmfoto 2014-07-30 um 16 08 57](https://cloud.githubusercontent.com/assets/298166/3750210/69b3f20e-17f3-11e4-9741-a84f9a519971.png)
