### PR TITLE
Added 'hideAfterPaletteSelect' option.

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -25,6 +25,7 @@
         showInitial: false,
         showPalette: false,
         showPaletteOnly: false,
+        hidePaletteAfterSelect: true,
         togglePaletteOnly: false,
         showSelectionPalette: true,
         localStorageKey: false,
@@ -448,7 +449,9 @@
                     set($(e.target).closest(".sp-thumb-el").data("color"));
                     move();
                     updateOriginalInput(true);
-                    hide();
+                    if (opts.hidePaletteAfterSelect) {
+                      hide();
+                    }
                 }
 
                 return false;

--- a/test/tests.js
+++ b/test/tests.js
@@ -181,6 +181,21 @@ test( "Palette click events work ", function() {
 
 });
 
+test( "Palette stays open after color select", function() {
+  var el = $("<input id='spec' value='red' />").spectrum({
+    showPalette: true,
+    hidePaletteAfterSelect: false,
+    palette: [
+      ["red", "green", "blue"]
+    ]
+  });
+
+  el.spectrum("show");
+  el.spectrum("container").find(".sp-thumb-el:nth-child(1)").click();
+
+  ok(!el.spectrum("container").hasClass('sp-hidden'), "palette is still visible after color selection");
+});
+
 test( "Local Storage Is Limited ", function() {
 
   var el = $("<input id='spec' value='red' />").spectrum({


### PR DESCRIPTION
In order to simply switch between more palette presets the
'hidePaletteAfterSelect' options was added to optionally prevent the
palette from closing after one preset was selected.
