### PR TITLE
Cancel does not always revert color correctly.

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -325,7 +325,8 @@
             cancelButton.bind("click.spectrum", function (e) {
                 e.stopPropagation();
                 e.preventDefault();
-                hide("cancel");
+                revert();
+                hide();
             });
 
             clearButton.attr("title", opts.clearText);
@@ -604,7 +605,7 @@
             hideAll();
             visible = true;
 
-            $(doc).bind("click.spectrum", hide);
+            $(doc).bind("click.spectrum", clickout);
             $(window).bind("resize.spectrum", resize);
             replacer.addClass("sp-active");
             container.removeClass("sp-hidden");
@@ -619,31 +620,26 @@
             boundElement.trigger('show.spectrum', [ colorOnShow ]);
         }
 
-        function hide(e) {
+        function clickout(e) {
+            if (clickoutFiresChange) {
+                updateOriginalInput(true);
+            }
+            else {
+                revert();
+            }
+            hide();
+        }
 
-            // Return on right click
-            if (e && e.type == "click" && e.button == 2) { return; }
-
+        function hide() {
             // Return if hiding is unnecessary
             if (!visible || flat) { return; }
             visible = false;
 
-            $(doc).unbind("click.spectrum", hide);
+            $(doc).unbind("click.spectrum", clickout);
             $(window).unbind("resize.spectrum", resize);
 
             replacer.removeClass("sp-active");
             container.addClass("sp-hidden");
-
-            var colorHasChanged = !tinycolor.equals(get(), colorOnShow);
-
-            if (colorHasChanged) {
-                if (clickoutFiresChange && e !== "cancel") {
-                    updateOriginalInput(true);
-                }
-                else {
-                    revert();
-                }
-            }
 
             callbacks.hide(get());
             boundElement.trigger('hide.spectrum', [ get() ]);

--- a/test/tests.js
+++ b/test/tests.js
@@ -610,3 +610,14 @@ test( "Cancelling reverts color", function() {
   equal ( el.spectrum("get").toName(), "red", "Color is reverted after clicking 'cancel'");
   el.spectrum("destroy");
 });
+
+test( "Choosing updates the color", function() {
+  var el = $("<input value='red' />").spectrum();
+  el.spectrum("show");
+  equal ( el.spectrum("get").toName(), "red", "Color is initialized");
+  el.spectrum("set", "orange");
+  equal ( el.spectrum("get").toName(), "orange", "Color is set");
+  el.spectrum("container").find(".sp-choose").click();
+  equal ( el.spectrum("get").toName(), "orange", "Color is kept after clicking 'choose'");
+  el.spectrum("destroy");
+});


### PR DESCRIPTION
Under any of the following circumstances, the cancel button does not revert the color as it should:

1) typing a color, then `tab`
2) selecting a color in the palette, if `hideAfterPaletteSelect` is `false`
3) or if the api `set` is called.

This is because `colorOnShow` is updated in `updateOriginalInput`, and these 3 circumstances call it. As the name implies, `colorOnShow` should be set only on show, so removing it appears to fix the issue.

I didn't add tests (see #241)
