### PR TITLE
fix #261: tap/click on sp-color rectangle does not move the reticle and ...

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -1061,9 +1061,7 @@
                     $(doc).bind(duringDragEvents);
                     $(doc.body).addClass("sp-dragging");
 
-                    if (!hasTouch) {
-                        move(e);
-                    }
+                    move(e);
 
                     prevent(e);
                 }


### PR DESCRIPTION
...'pick' the pointed-at color.