### PR TITLE
Fix for bug #85

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -360,6 +360,10 @@
                 e.stopPropagation();
                 e.preventDefault();
 
+                if (IE && textInput.is(":focus")) {
+                    textInput.trigger('change');
+                }
+
                 if (isValid()) {
                     updateOriginalInput(true);
                     hide();


### PR DESCRIPTION
IE 10 does not let go of the focus to the input element when the picker is closed
So this fix will check if IE is in use and if the textbox still has focus.
If so then trigger the change event as the normal focus change would do.
