### PR TITLE
Fix French language file.

### DIFF
--- a/i18n/jquery.spectrum-fr.js
+++ b/i18n/jquery.spectrum-fr.js
@@ -9,8 +9,8 @@
         chooseText: "Valider",
         clearText: "Effacer couleur sélectionnée",
         noColorSelectedText: "Aucune couleur sélectionnée",
-        togglePaletteMoreText: "plus",
-        togglePaletteLessText: "moins"
+        togglePaletteMoreText: "Plus",
+        togglePaletteLessText: "Moins"
     };
 
     $.extend($.fn.spectrum.defaults, localization);


### PR DESCRIPTION
Previous translation for **clearText** (_"Sélection de la couleur claire"_) actually means _"Light color selection"_.

And I think the original English string for **clearText** should be _"Clear Selected Color"_ instead of _"Clear Color Selection"_. That would make it more symmetrical to **noColorSelectedText** (_"No Color Selected"_).
