### PR TITLE
you can safely mangle now, see TinyColor/pull/79

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,7 +24,7 @@ module.exports = function(grunt) {
         },
         files: {
           src: ['i18n/*.js', 'test/tests.js']
-        }
+        },
       },
 
       all: ['spectrum.js']
@@ -33,6 +33,7 @@ module.exports = function(grunt) {
 
     uglify: {
       options: {
+        mangle: false
       },
       dist: {
         files: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,7 +24,7 @@ module.exports = function(grunt) {
         },
         files: {
           src: ['i18n/*.js', 'test/tests.js']
-        },
+        }
       },
 
       all: ['spectrum.js']
@@ -33,7 +33,6 @@ module.exports = function(grunt) {
 
     uglify: {
       options: {
-        mangle: false
       },
       dist: {
         files: {

--- a/spectrum.js
+++ b/spectrum.js
@@ -1191,7 +1191,7 @@
         mathMax = math.max,
         mathRandom = math.random;
 
-    var tinycolor = function (color, opts) {
+    var tinycolor = function tinycolor (color, opts) {
 
         color = (color) ? color : '';
         opts = opts || { };

--- a/spectrum.js
+++ b/spectrum.js
@@ -1191,7 +1191,7 @@
         mathMax = math.max,
         mathRandom = math.random;
 
-    var tinycolor = function tinycolor (color, opts) {
+    var tinycolor = function (color, opts) {
 
         color = (color) ? color : '';
         opts = opts || { };


### PR DESCRIPTION
You can safely mangle variable names now without breaking IE8, for an even smaller minified build.

See https://github.com/bgrins/TinyColor/pull/79
which links to 
https://github.com/hammerjs/jquery.hammer.js/issues/20

If I may also suggest pulling TinyColor out of the source and making it a versioned-requirement instead.

