### PR TITLE
Guard against Chrome creating a fake event.touches[0] object

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -1047,9 +1047,9 @@
                     return stop();
                 }
 
-                var touches = e.originalEvent && e.originalEvent.touches;
-                var pageX = touches ? touches[0].pageX : e.pageX;
-                var pageY = touches ? touches[0].pageY : e.pageY;
+                var t0 = e.originalEvent && e.originalEvent.touches && e.originalEvent.touches[0];
+                var pageX = t0 && t0.pageX || e.pageX;
+                var pageY = t0 && t0.pageY || e.pageY;
 
                 var dragX = Math.max(0, Math.min(pageX - offset.left, maxWidth));
                 var dragY = Math.max(0, Math.min(pageY - offset.top, maxHeight));


### PR DESCRIPTION
Chrome was creating a blank object in event.touches[0], see screenshot. The symptom of this is that pageX and pageY were always undefined on a drag.
![screen shot 2015-01-20 at 10 17 07 pm](https://cloud.githubusercontent.com/assets/1398375/5830706/839c6cb8-a0f2-11e4-85c7-cc119555196a.png)
