### PR TITLE
Allow "locking" a color by double-clicking it.

### DIFF
--- a/spectrum.css
+++ b/spectrum.css
@@ -333,6 +333,9 @@ See http://bgrins.github.io/spectrum/themes/ for instructions.
 .sp-palette .sp-thumb-el:hover, .sp-palette .sp-thumb-el.sp-thumb-active {
     border-color: orange;
 }
+.sp-palette .sp-thumb-el.sp-thumb-active {
+    border-color: red;
+}
 .sp-thumb-el {
     position:relative;
 }


### PR DESCRIPTION
This alters the color's selection state and can be queried via the "isLocked" method.

I didn't bother adding docs for this because it's so use-case dependent and I don't plan
to submit a PR to upstream.