### PR TITLE
Add a function to get RGBA string value

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -1297,6 +1297,9 @@
               "rgb("  + mathRound(this._r) + ", " + mathRound(this._g) + ", " + mathRound(this._b) + ")" :
               "rgba(" + mathRound(this._r) + ", " + mathRound(this._g) + ", " + mathRound(this._b) + ", " + this._roundA + ")";
         },
+        toRgbaString: function() {
+            return "rgba(" + mathRound(this._r) + ", " + mathRound(this._g) + ", " + mathRound(this._b) + ", " + this._a + ")";
+        },
         toPercentageRgb: function() {
             return { r: mathRound(bound01(this._r, 255) * 100) + "%", g: mathRound(bound01(this._g, 255) * 100) + "%", b: mathRound(bound01(this._b, 255) * 100) + "%", a: this._a };
         },


### PR DESCRIPTION
Get rgba value even if the value of _a is 1, because in some cases we want to work only with alpha  and not change the color.