### PR TITLE
Change "!" to "#ffffff" as default color/value

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -73,8 +73,8 @@
         return contains(style.backgroundColor, 'rgba') || contains(style.backgroundColor, 'hsla');
     })(),
     inputTypeColorSupport = (function() {
-        var colorInput = $("<input type='color' value='!' />")[0];
-        return colorInput.type === "color" && colorInput.value !== "!";
+        var colorInput = $("<input type='color' value='#ffffff' />")[0]; // change "!" to "#ffffff" as default color/value
+        return colorInput.type === "color" && colorInput.value !== "#ffffff";
     })(),
     replaceInput = [
         "<div class='sp-replacer'>",


### PR DESCRIPTION
Change "!" to "#ffffff" as default color/value to get rid of the "The specified value '!' does not conform to the required format." error.