### PR TITLE
Prevent warning for browser input[type=color] support unless if initialized with an actual input[type=color]

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -72,10 +72,6 @@
         style.cssText = 'background-color:rgba(0,0,0,.5)';
         return contains(style.backgroundColor, 'rgba') || contains(style.backgroundColor, 'hsla');
     })(),
-    inputTypeColorSupport = (function() {
-        var colorInput = $("<input type='color' value='!' />")[0];
-        return colorInput.type === "color" && colorInput.value !== "!";
-    })(),
     replaceInput = [
         "<div class='sp-replacer'>",
             "<div class='sp-preview'><div class='sp-preview-inner'></div></div>",
@@ -230,7 +226,7 @@
             chooseButton = container.find(".sp-choose"),
             toggleButton = container.find(".sp-palette-toggle"),
             isInput = boundElement.is("input"),
-            isInputTypeColor = isInput && inputTypeColorSupport && boundElement.attr("type") === "color",
+            isInputTypeColor = isInput && boundElement.attr("type") === "color" && inputTypeColorSupport(),
             shouldReplace = isInput && !flat,
             replacer = (shouldReplace) ? $(replaceInput).addClass(theme).addClass(opts.className).addClass(opts.replacerClassName) : $([]),
             offsetElement = (shouldReplace) ? replacer : boundElement,
@@ -1110,6 +1106,10 @@
         };
     }
 
+    function inputTypeColorSupport() {
+        return $.fn.spectrum.inputTypeColorSupport();
+    }
+
     /**
     * Define a jQuery plugin
     */
@@ -1163,14 +1163,22 @@
     $.fn.spectrum.loadOpts = {};
     $.fn.spectrum.draggable = draggable;
     $.fn.spectrum.defaults = defaultOpts;
+    $.fn.spectrum.inputTypeColorSupport = function inputTypeColorSupport() {
+        if (typeof inputTypeColorSupport._cachedResult === "undefined") {
+            var colorInput = $("<input type='color' value='!' />")[0];
+            inputTypeColorSupport._cachedResult = colorInput.type === "color" && colorInput.value !== "!";
+        }
+        return inputTypeColorSupport._cachedResult;
+    };
 
     $.spectrum = { };
     $.spectrum.localization = { };
     $.spectrum.palettes = { };
 
     $.fn.spectrum.processNativeColorInputs = function () {
-        if (!inputTypeColorSupport) {
-            $("input[type=color]").spectrum({
+        var colorInputs = $("input[type=color]");
+        if (colorInputs.length && !inputTypeColorSupport()) {
+            colorInputs.spectrum({
                 preferredFormat: "hex6"
             });
         }

--- a/test/index.html
+++ b/test/index.html
@@ -12,5 +12,7 @@
   <script src="../spectrum.js"></script>
   <script src="qunit.js"></script>
   <script src="tests.js"></script>
+
+  <input type="color" id="type-color-on-page" />
 </body>
 </html>

--- a/test/tests.js
+++ b/test/tests.js
@@ -3,6 +3,8 @@
 // Author: Brian Grinstead
 // License: MIT
 
+// Pretend like the color inputs aren't supported for initial load.
+$.fn.spectrum.inputTypeColorSupport = function() { return false; };
 
 module("Initialization");
 
@@ -24,6 +26,22 @@ test( "jQuery Plugin Can Be Created", function() {
 
   equal(el.spectrum("container"), el, "After destroying spectrum, string function returns input.");
 
+});
+
+test ("Polyfill", function() {
+  var el = $("#type-color-on-page");
+  ok (el.spectrum("get").toHex, "The input[type=color] has been initialized on load");
+  el.spectrum("destroy");
+
+  // Pretend like the color inputs are supported.
+  $.fn.spectrum.inputTypeColorSupport = function() { return true; };
+
+  el = $("<input type='color' value='red' />").spectrum({
+    allowEmpty: true
+  });
+  el.spectrum("set", null);
+  ok(el.spectrum("get"), "input[type] color does not allow null values");
+  el.spectrum("destroy");
 });
 
 test( "Per-element Options Are Read From Data Attributes", function() {
@@ -264,6 +282,20 @@ test( "Local Storage Is Limited ", function() {
 });
 
 module("Options");
+
+test ("allowEmpty", function() {
+  var el = $("<input value='red' />").spectrum({
+    allowEmpty: true
+  });
+  el.spectrum("set", null);
+  ok(!el.spectrum("get"), "input[type] color does not allow null values");
+  el.spectrum("destroy");
+
+  el = $("<input value='red' />").spectrum();
+  el.spectrum("set", null);
+  ok(el.spectrum("get"), "input[type] color does not allow null values");
+  el.spectrum("destroy");
+});
 
 test ("replacerClassName", function() {
   var el = $("<input />").appendTo("body").spectrum({


### PR DESCRIPTION
See #292