### PR TITLE
Add keyboard navigation to the color palette, for accessibility.

### DIFF
--- a/spectrum.css
+++ b/spectrum.css
@@ -330,6 +330,9 @@ See http://bgrins.github.io/spectrum/themes/ for instructions.
     cursor: pointer;
     border:solid 2px transparent;
 }
+.sp-palette .sp-thumb-el.sp-thumb-focus {
+    outline: 1px solid red;
+}
 .sp-palette .sp-thumb-el:hover, .sp-palette .sp-thumb-el.sp-thumb-active {
     border-color: orange;
 }


### PR DESCRIPTION
Allow tabbing into the color picker, and focus to be set on a
square in the color picker.  Allow using arrow keys to move around
the color palette and set focus.  Allow Enter key to select the
focused color.  This is done with a new keydown handler.

This is needed in order to comply with accessibility requirements.
Note that the color gradient is not yet accessible, just the palette.

https://github.com/bgrins/spectrum/issues/295