### PR TITLE
'addInitialToSelectionPalette' option

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -40,6 +40,7 @@
         hideAfterPaletteSelect: false,
         togglePaletteOnly: false,
         showSelectionPalette: true,
+        addInitialToSelectionPalette: true,
         localStorageKey: false,
         appendTo: "body",
         maxSelectionSize: 7,
@@ -180,6 +181,7 @@
         var opts = instanceOptions(o, element),
             flat = opts.flat,
             showSelectionPalette = opts.showSelectionPalette,
+            addInitialToSelectionPalette = opts.addInitialToSelectionPalette,
             localStorageKey = opts.localStorageKey,
             theme = opts.theme,
             callbacks = opts.callbacks,
@@ -444,7 +446,9 @@
                 updateUI();
                 currentPreferredFormat = preferredFormat || tinycolor(initialColor).format;
 
-                addColorToSelectionPalette(initialColor);
+                if (addInitialToSelectionPalette) {
+                    addColorToSelectionPalette(initialColor);
+                }
             }
             else {
                 updateUI();

--- a/spectrum.js
+++ b/spectrum.js
@@ -2,7 +2,7 @@
 // https://github.com/bgrins/spectrum
 // Author: Brian Grinstead
 // License: MIT
-// fork test lalala
+
 (function (factory) {
     "use strict";
 

--- a/spectrum.js
+++ b/spectrum.js
@@ -2,7 +2,7 @@
 // https://github.com/bgrins/spectrum
 // Author: Brian Grinstead
 // License: MIT
-
+// fork test lalala
 (function (factory) {
     "use strict";
 


### PR DESCRIPTION
Hi, 

First of all thanks for the great plugin.

This pull request is for adding an option, which I named 'addInitialToSelectionPalette'.
If you specify this value false, the initial color will not be automatically added to the selection palette.
(default value is true so there will be no change in current behavior)

This change expands the options and making the plugin more customizable.

The problem I encountered for which I required to add this option:
I use multiple color pickers in multiple views which are handled by a layout system that handles removing views from the DOM and rerendering them when necessary.
I noticed an issue that every time a spectrum color picker is rendered to the DOM, it's initial color is automatically added to the selection palette even if it was not interacted with / shown.
This cause the selection palette to show colors which were not the recently selected ones.
By adding this option, the initial color was not added on initialization of the color picker.

Take note, this also means that it is possible for the color picker to show without any color marked as selected in the selection palette (since this color is not automatically added).
This behavior seems fine to me and as desired.

Thanks,
Asaf.