### PR TITLE
Change clickoutFiresChange default from false to true

### DIFF
--- a/docs/docs.js
+++ b/docs/docs.js
@@ -261,12 +261,12 @@ $("#togglePaletteOnly").spectrum({
 });
 
 $("#clickoutFiresChange").spectrum({
-    clickoutFiresChange: true,
     change: updateBorders
 });
 
 $("#clickoutDoesntFireChange").spectrum({
-    change: updateBorders
+    change: updateBorders,
+    clickoutFiresChange: false
 });
 
 $("#showInitial").spectrum({

--- a/index.html
+++ b/index.html
@@ -506,7 +506,7 @@ $("#hideAfterPaletteSelect").spectrum({
         <div class='option-content'>
             <div class='description'>
                 <p>
-                When clicking outside of the colorpicker, you can force it to fire a <code>change</code> event rather than having it revert the change.
+                When clicking outside of the colorpicker, you can force it to fire a <code>change</code> event rather than having it revert the change.  This is <code>true</code> by default.
                 </p>
             </div>
 
@@ -515,7 +515,7 @@ $("#clickoutFiresChange").spectrum({
     clickoutFiresChange: true
 });
 $("#clickoutDoesntChange").spectrum({
-
+    clickoutFiresChange: false
 });
             </pre>
 

--- a/spectrum.js
+++ b/spectrum.js
@@ -33,7 +33,7 @@
         showInput: false,
         allowEmpty: false,
         showButtons: true,
-        clickoutFiresChange: false,
+        clickoutFiresChange: true,
         showInitial: false,
         showPalette: false,
         showPaletteOnly: false,

--- a/test/tests.js
+++ b/test/tests.js
@@ -317,6 +317,29 @@ test ("allowEmpty", function() {
   el.spectrum("destroy");
 });
 
+test ("clickoutFiresChange", function() {
+  var el = $("<input value='red' />").spectrum({
+    clickoutFiresChange: false
+  });
+  el.spectrum("show");
+  equal ( el.spectrum("get").toName(), "red", "Color is initialized");
+  el.spectrum("set", "orange");
+  equal ( el.spectrum("get").toName(), "orange", "Color is set");
+  $(document).click();
+  equal ( el.spectrum("get").toName(), "red", "Color is reverted after clicking 'cancel'");
+  el.spectrum("destroy");
+
+  // Try again with default behavior (clickoutFiresChange = true)
+  el = $("<input value='red' />").spectrum();
+  el.spectrum("show");
+  equal ( el.spectrum("get").toName(), "red", "Color is initialized");
+  el.spectrum("set", "orange");
+  equal ( el.spectrum("get").toName(), "orange", "Color is set");
+  $(document).click();
+  equal ( el.spectrum("get").toName(), "orange", "Color is changed after clicking out");
+  el.spectrum("destroy");
+});
+
 test ("replacerClassName", function() {
   var el = $("<input />").appendTo("body").spectrum({
     replacerClassName: "test"


### PR DESCRIPTION
I think the default behavior of a clickout reverting the selected color is wrong.  We should treat 'cancel' as a revert, and otherwise allow people to dismiss the colorpicker without losing their selected color.