### PR TITLE
to prevent: 'The specified value ! does not conform..' Warning messages in chrome console.

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -1184,8 +1184,8 @@
     $.fn.spectrum.defaults = defaultOpts;
     $.fn.spectrum.inputTypeColorSupport = function inputTypeColorSupport() {
         if (typeof inputTypeColorSupport._cachedResult === "undefined") {
-            var colorInput = $("<input type='color' value='!' />")[0];
-            inputTypeColorSupport._cachedResult = colorInput.type === "color" && colorInput.value !== "!";
+            var colorInput = $("<input type='color'/>")[0]; // if color element is supported, value will default to not null
+            inputTypeColorSupport._cachedResult = colorInput.type === "color" && colorInput.value !== "";
         }
         return inputTypeColorSupport._cachedResult;
     };


### PR DESCRIPTION
The theory behind this patch is that an `<input/>` should always have a value, and `type=color` inputs should always have a color like value, and never blank as the default.

Related to:
  https://github.com/bgrins/spectrum/issues/291
  https://github.com/bgrins/spectrum/pull/292
  https://github.com/bgrins/spectrum/pull/296