### PR TITLE
fix change event call #321

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -463,8 +463,8 @@
                 else {
                     set($(e.target).closest(".sp-thumb-el").data("color"));
                     move();
-                    updateOriginalInput(true);
                     if (opts.hideAfterPaletteSelect) {
+                      updateOriginalInput(true);
                       hide();
                     }
                 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -193,6 +193,7 @@ test( "Palette Events Fire In Correct Order ", function() {
   expect(2);
   var el = $("<input id='spec' value='red' />").spectrum({
     showPalette: true,
+    hideAfterPaletteSelect : true, 
     palette: [
       ["red", "green", "blue"]
     ],


### PR DESCRIPTION
Palette clicks always cause the "change" callback to fire. This is probably an issue : this behavior has to happen only if hideAfterPaletteSelect is set to true.
(According to the reference manual, change event "only happens when the input is closed or the 'Choose' button is clicked")