### PR TITLE
Positioning bug fix

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -890,9 +890,9 @@
             if (!flat) {
                 container.css("position", "absolute");
                 if (opts.offset) {
-                    container.offset(opts.offset);
+                    container.css(opts.offset);
                 } else {
-                    container.offset(getOffset(container, offsetElement));
+                    container.css(getOffset(container, offsetElement));
                 }
             }
 


### PR DESCRIPTION
There is a great possibility to pose dropdown colorpicker about button using margins on `.sp-container` in CSS, but `.offset` method calculates such `top` and `left` that dissolve margins and colorpicker stands on it's place. If `.css` method is used margins work.