### PR TITLE
Fix an issue with write attempt to read-only property of ClientRect

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -982,6 +982,17 @@
         var viewWidth = docElem.clientWidth + $(doc).scrollLeft();
         var viewHeight = docElem.clientHeight + $(doc).scrollTop();
         var offset = input.offset();
+
+        // Note: ClientRect object does not allow its properties to be written to therefore a new object has to be created.
+        offset = {
+            top: offset.top,
+            left: offset.left,
+            bottom: offset.bottom,
+            right: offset.right,
+            height: offset.height,
+            width: offset.width
+        };
+
         offset.top += inputHeight;
 
         offset.left -=


### PR DESCRIPTION
any attempt to `getOffset` results in `TypeError: Cannot set property top of #<ClientRect> which has only a getter`. It is so due to the fact that in `getOffset` an attempt to write read-only properties of `ClientRect` is made. `ClientRect` properties are getters but setters are not defined.
