### PR TITLE
Ability to change allowEmpty from false to true

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -259,6 +259,8 @@
                     }
                 }
             }
+            
+            allowEmpty = opts.allowEmpty && !doc.isInputTypeColor;
 
             container.toggleClass("sp-flat", flat);
             container.toggleClass("sp-input-disabled", !opts.showInput);
@@ -284,10 +286,6 @@
 
             if (shouldReplace) {
                 boundElement.after(replacer).hide();
-            }
-
-            if (!allowEmpty) {
-                clearButton.hide();
             }
 
             if (flat) {

--- a/spectrum.js
+++ b/spectrum.js
@@ -260,7 +260,9 @@
                 }
             }
             
-            allowEmpty = opts.allowEmpty && !doc.isInputTypeColor;
+
+            isInputTypeColor = isInput && boundElement.attr("type") === "color" && inputTypeColorSupport();
+            allowEmpty = opts.allowEmpty && !isInputTypeColor;
 
             container.toggleClass("sp-flat", flat);
             container.toggleClass("sp-input-disabled", !opts.showInput);

--- a/spectrum.js
+++ b/spectrum.js
@@ -259,7 +259,6 @@
                     }
                 }
             }
-            
 
             isInputTypeColor = isInput && boundElement.attr("type") === "color" && inputTypeColorSupport();
             allowEmpty = opts.allowEmpty && !isInputTypeColor;


### PR DESCRIPTION
There was a couple weird things going on that prevented this from happening in the current build. 

For one, if `allowEmpty` was false, `clearButton` was permanently hidden. After changing allowEmpty to true it was still empty, even with the `sp-clear-enabled` class applied. I couldn't find any benefit to hiding the button (it seems to hide itself just fine without using `.hide()`), so I removed it. 

Two, once `allowEmpty` is false it was always false, so when trying to apply new options it's pretty much skipped over.