### PR TITLE
Ability to change allowEmpty from false to true

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -260,6 +260,9 @@
                 }
             }
 
+            isInputTypeColor = isInput && boundElement.attr("type") === "color" && inputTypeColorSupport();
+            allowEmpty = opts.allowEmpty && !isInputTypeColor;
+
             container.toggleClass("sp-flat", flat);
             container.toggleClass("sp-input-disabled", !opts.showInput);
             container.toggleClass("sp-alpha-enabled", opts.showAlpha);
@@ -284,10 +287,6 @@
 
             if (shouldReplace) {
                 boundElement.after(replacer).hide();
-            }
-
-            if (!allowEmpty) {
-                clearButton.hide();
             }
 
             if (flat) {


### PR DESCRIPTION
There was a couple weird things going on that prevented this from happening in the current build.

For one, if allowEmpty was false, clearButton was permanently hidden. After changing allowEmpty to true it was still empty, even with the sp-clear-enabled class applied. I couldn't find any benefit to hiding the button (it seems to hide itself just fine without using .hide()), so I removed it.

Two, once allowEmpty is false it was always false, so when trying to apply new options it's pretty much skipped over.

Weird fix but I couldn't access isInputTypeColor in applyOptions for unknown reasons, so I had to give it a value again.