### PR TITLE
Custom color names

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -234,6 +234,7 @@
             previewElement = replacer.find(".sp-preview-inner"),
             initialColor = opts.color || (isInput && boundElement.val()),
             colorOnShow = false,
+            currentColorOnShow = false,
             preferredFormat = opts.preferredFormat,
             currentPreferredFormat = preferredFormat,
             clickoutFiresChange = !opts.showButtons || opts.clickoutFiresChange,
@@ -553,7 +554,7 @@
 
         function drawInitial() {
             if (opts.showInitial) {
-                var initial = colorOnShow;
+                var initial = currentColorOnShow = colorOnShow;
                 var current = get();
                 initialColorContainer.html(paletteTemplate([initial, current], current, "sp-palette-row-initial", opts));
             }
@@ -858,8 +859,13 @@
 
         function updateOriginalInput(fireCallback) {
             var color = get(),
-                displayColor = '',
-                hasChanged = !tinycolor.equals(color, colorOnShow);
+                displayColor = '';
+
+            if (currentColorOnShow) {
+                var hasChanged = !tinycolor.equals(color, currentColorOnShow);
+            }
+
+			currentColorOnShow = color;
 
             if (color) {
                 displayColor = color.toString(currentPreferredFormat);

--- a/spectrum.js
+++ b/spectrum.js
@@ -554,8 +554,7 @@
 
         function drawInitial() {
             if (opts.showInitial) {
-                var initial = colorOnShow;
-                currentColorOnShow = colorOnShow;
+                var initial = currentColorOnShow = colorOnShow;
                 var current = get();
                 initialColorContainer.html(paletteTemplate([initial, current], current, "sp-palette-row-initial", opts));
             }
@@ -860,11 +859,10 @@
 
         function updateOriginalInput(fireCallback) {
             var color = get(),
-                displayColor = '',
-                hasChanged = false;
+                displayColor = '';
 
             if (currentColorOnShow) {
-                hasChanged = !tinycolor.equals(color, currentColorOnShow);
+                var hasChanged = !tinycolor.equals(color, currentColorOnShow);
             }
 
 			currentColorOnShow = color;

--- a/spectrum.js
+++ b/spectrum.js
@@ -58,7 +58,8 @@
         palette: [["#ffffff", "#000000", "#ff0000", "#ff8000", "#ffff00", "#008000", "#0000ff", "#4b0082", "#9400d3"]],
         selectionPalette: [],
         disabled: false,
-        offset: null
+        offset: null,
+        customColorNames: {}
     },
     spectrums = [],
     IE = !!/msie/i.exec( window.navigator.userAgent ),
@@ -270,6 +271,8 @@
             container.toggleClass("sp-palette-only", opts.showPaletteOnly);
             container.toggleClass("sp-initial-disabled", !opts.showInitial);
             container.addClass(opts.className).addClass(opts.containerClassName);
+
+			$.extend(tinycolor.hexNames, opts.customColorNames);
 
             reflow();
         }

--- a/spectrum.js
+++ b/spectrum.js
@@ -861,11 +861,7 @@
         function updateOriginalInput(fireCallback) {
             var color = get(),
                 displayColor = '',
-                hasChanged = false;
-
-            if (currentColorOnShow) {
                 hasChanged = !tinycolor.equals(color, currentColorOnShow);
-            }
 
 			currentColorOnShow = color;
 

--- a/spectrum.js
+++ b/spectrum.js
@@ -861,7 +861,11 @@
         function updateOriginalInput(fireCallback) {
             var color = get(),
                 displayColor = '',
+                hasChanged = false;
+
+            if (currentColorOnShow) {
                 hasChanged = !tinycolor.equals(color, currentColorOnShow);
+            }
 
 			currentColorOnShow = color;
 

--- a/spectrum.js
+++ b/spectrum.js
@@ -554,7 +554,8 @@
 
         function drawInitial() {
             if (opts.showInitial) {
-                var initial = currentColorOnShow = colorOnShow;
+                var initial = colorOnShow;
+                currentColorOnShow = colorOnShow;
                 var current = get();
                 initialColorContainer.html(paletteTemplate([initial, current], current, "sp-palette-row-initial", opts));
             }
@@ -859,10 +860,11 @@
 
         function updateOriginalInput(fireCallback) {
             var color = get(),
-                displayColor = '';
+                displayColor = '',
+                hasChanged = false;
 
             if (currentColorOnShow) {
-                var hasChanged = !tinycolor.equals(color, currentColorOnShow);
+                hasChanged = !tinycolor.equals(color, currentColorOnShow);
             }
 
 			currentColorOnShow = color;

--- a/spectrum.js
+++ b/spectrum.js
@@ -234,7 +234,6 @@
             previewElement = replacer.find(".sp-preview-inner"),
             initialColor = opts.color || (isInput && boundElement.val()),
             colorOnShow = false,
-            currentColorOnShow = false,
             preferredFormat = opts.preferredFormat,
             currentPreferredFormat = preferredFormat,
             clickoutFiresChange = !opts.showButtons || opts.clickoutFiresChange,
@@ -554,7 +553,7 @@
 
         function drawInitial() {
             if (opts.showInitial) {
-                var initial = currentColorOnShow = colorOnShow;
+                var initial = colorOnShow;
                 var current = get();
                 initialColorContainer.html(paletteTemplate([initial, current], current, "sp-palette-row-initial", opts));
             }
@@ -859,13 +858,8 @@
 
         function updateOriginalInput(fireCallback) {
             var color = get(),
-                displayColor = '';
-
-            if (currentColorOnShow) {
-                var hasChanged = !tinycolor.equals(color, currentColorOnShow);
-            }
-
-			currentColorOnShow = color;
+                displayColor = '',
+                hasChanged = !tinycolor.equals(color, colorOnShow);
 
             if (color) {
                 displayColor = color.toString(currentPreferredFormat);


### PR DESCRIPTION
New option customColorNames allows to pass custom color names so they
are used when the preferredFormat option is set to "name"

    customColorNames: {
        'fbd4da': 'pale pink',
        'eee': 'light grey',
        'b60942': 'dark red'
    }
