### PR TITLE
Return rgba to original input when alpha channel is used

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -857,12 +857,19 @@
         }
 
         function updateOriginalInput(fireCallback) {
-            var color = get(),
+            var format = currentPreferredFormat;
+            if (currentAlpha < 1 && !(currentAlpha === 0 && format === "name")) {
+                if (format === "hex" || format === "hex3" || format === "hex6" || format === "name") {
+                    format = "rgb";
+                }
+            }
+
+            var color = get({ format: format }),
                 displayColor = '',
                 hasChanged = !tinycolor.equals(color, colorOnShow);
 
             if (color) {
-                displayColor = color.toString(currentPreferredFormat);
+                displayColor = color.toString(format);
                 // Update the selection palette with the current color
                 addColorToSelectionPalette(color);
             }


### PR DESCRIPTION
When you set preferredFormat eg. to "hex" then the colorpicker result in the original input field will always be in hex, even if showAlpha=true and the user selected an alpha less than 1. The colorpicker should return rgba instead (like the preview input field does).