### PR TITLE
Update spectrum when input changed

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -303,6 +303,10 @@
                 appendTo.append(container);
             }
 
+            if (isInput) {
+                boundElement.bind("input", function () { set($(this).val()); });
+            }
+
             updateSelectionPaletteFromStorage();
 
             offsetElement.bind("click.spectrum touchstart.spectrum", function (e) {


### PR DESCRIPTION
When the original input is shown, and you type something, then spectrum doesn't update. I guess this was setup to prevent event loops, but as long as you don't call "updateOriginalInput" from the input event handler, you can avoid those loops.

Here is the difference:
current master: http://jsfiddle.net/7sun5j3c/
pull request: http://jsfiddle.net/7sun5j3c/2/
You have to type something into the input field