### PR TITLE
add datalist support

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -533,6 +533,18 @@
             return unique.reverse().slice(0, opts.maxSelectionSize);
         }
 
+        function readDatalistPalette() {
+            var listID = $(element).attr('list');
+            if(listID) {
+                option("showPalette", true);
+                option("palette", $("datalist#" + listID).find("option").filter(function() {
+                    return !$(this).is(":disabled") && $.trim(this.value) !== "";
+                }).map(function() {
+                    return this.value;
+                }).toArray());
+            }
+        }
+
         function drawPalette() {
 
             var currentColor = get();
@@ -616,6 +628,8 @@
             if (callbacks.beforeShow(get()) === false || event.isDefaultPrevented()) {
                 return;
             }
+
+            readDatalistPalette();
 
             hideAll();
             visible = true;

--- a/test/tests.js
+++ b/test/tests.js
@@ -236,6 +236,22 @@ test( "Palette click events work ", function() {
 
 });
 
+test( "Palette defined in html datalist is read", function() {
+  var container = $("<input id='spec' value='red' list='testlist' /><datalist id='testlist'>" +
+      "<option>#00FF00</option><option>#FF00FF</option></datalist>").appendTo("body");
+  var el = $("#spec").spectrum({
+    palette: [
+      ["red", "green", "blue"]
+    ]
+  });
+
+  el.spectrum("show");
+  deepEqual (
+    el.spectrum("option", "palette"), ["#00FF00", "#FF00FF"],
+    "datalist should replace default palette"
+  );
+});
+
 test( "hideAfterPaletteSelect: Palette stays open after color select", function() {
   var el = $("<input id='spec' value='red' />").spectrum({
     showPalette: true,


### PR DESCRIPTION
Hey, quite nice little library.

I would like to use it as polyfil. But i need spectrum to read the palette from the html datalist. I saw you like to have it too (#220). I found a two year old PR (#103). I tried to simply it be making the assumtion, that if the input field has a datalist attached (which should be a special case), the default palette would be replace by the datalist colors.

I'm not quite sure if this is a reasonable approach. What do you think?