### PR TITLE
fix: palette view - respect transparency of background color

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -136,7 +136,9 @@
             var current = p[i];
             if(current) {
                 var tiny = tinycolor(current);
-                var c = tiny.toHsl().l < 0.5 ? "sp-thumb-el sp-thumb-dark" : "sp-thumb-el sp-thumb-light";
+                var hsl = tiny.toHsl();
+                var darkColor = hsl.l + (1 - hsl.a);
+                var c = darkColor < 1.0 ? "sp-thumb-el sp-thumb-dark" : "sp-thumb-el sp-thumb-light";
                 c += (tinycolor.equals(color, current)) ? " sp-thumb-active" : "";
                 var formattedString = tiny.toString(opts.preferredFormat || "rgb");
                 var swatchStyle = rgbaSupport ? ("background-color:" + tiny.toRgbString()) : "filter:" + tiny.toFilter();


### PR DESCRIPTION
The check signs in the palette view boxes respect only lumincance of background color.
The alpha value has to be considered as well to decide for a dark or light check sign.

The introduced formula is taking care of that.