### PR TITLE
Avoid positioning issue when changing options for hidden pickers

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -877,6 +877,9 @@
         }
 
         function reflow() {
+            if (!visible) {
+                return; // Calculations would be useless and wouldn't be reliable anyways
+            }
             dragWidth = dragger.width();
             dragHeight = dragger.height();
             dragHelperHeight = dragHelper.height();

--- a/test/tests.js
+++ b/test/tests.js
@@ -505,6 +505,7 @@ test ("Tooltip is formatted based on preferred format", function() {
     showPalette: true,
     palette: [["red", "rgba(255, 255, 255, .5)", "rgb(0, 0, 255)"]]
   });
+  el.spectrum("show");
 
   function getTitlesString() {
     return el.spectrum("container").find(".sp-thumb-el").map(function() {


### PR DESCRIPTION
[tldr;] This commit can not hurt, and I swear it helps.

We encountered some strange issues that are a bit tricky to reproduce.
If there is a spectrum picker that is near the bottom of the screen, that is closed and we change the options, the call to `reflow` would screw things up, so that if it's later shown, the first call to `reflow` would get a very wrong value for `outerHeight()`, so that the position would be wrong. Any subsequent call to `reflow` would correct the situation.
I didn't even try writing a test for this. Debugging in chrome is hard enough, as any resize also triggers `reflow`.
It seems obvious to me that there is no upside to calling `reflow` when a picker is hidden, and since `outerHeight()` & al. are `0`, which is not the values the calculation is looking for, the results would not be relevant anyways. 