### PR TITLE
Remove stopPropagation on choose & cancel buttons

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -332,7 +332,6 @@
 
             cancelButton.text(opts.cancelText);
             cancelButton.bind("click.spectrum", function (e) {
-                e.stopPropagation();
                 e.preventDefault();
                 revert();
                 hide();
@@ -353,7 +352,6 @@
 
             chooseButton.text(opts.chooseText);
             chooseButton.bind("click.spectrum", function (e) {
-                e.stopPropagation();
                 e.preventDefault();
 
                 if (IE && textInput.is(":focus")) {


### PR DESCRIPTION
It's not ideal to use stopPropagation() on these two bottons in case if users of the library wishes to intercept the clicking event on them and perform explicit actions on colour picked through hex code, for example. There are also plenty of other places that use stopPropagation that may need some cleanup, but let's start with these two for now.