### PR TITLE
Fix loss of precision on alpha values

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -719,7 +719,7 @@
                 h: currentHue,
                 s: currentSaturation,
                 v: currentValue,
-                a: Math.round(currentAlpha * 100) / 100
+                a: Math.round(currentAlpha * 1000) / 1000
             }, { format: opts.format || currentPreferredFormat });
         }
 
@@ -1254,7 +1254,7 @@
         this._g = rgb.g,
         this._b = rgb.b,
         this._a = rgb.a,
-        this._roundA = mathRound(100*this._a) / 100,
+        this._roundA = mathRound(1000 * this._a) / 1000,
         this._format = opts.format || rgb.format;
         this._gradientType = opts.gradientType;
 
@@ -1295,7 +1295,7 @@
         },
         setAlpha: function(value) {
             this._a = boundAlpha(value);
-            this._roundA = mathRound(100*this._a) / 100;
+            this._roundA = mathRound(1000 * this._a) / 1000;
             return this;
         },
         toHsv: function() {

--- a/test/tests.js
+++ b/test/tests.js
@@ -579,13 +579,13 @@ test( "Methods work as described", function() {
     (function() {
       var i, argb, a;
       for (i = 0; i < 16; i++) {
-        argb = ('0' + i.toString(16) + '000000').slice(-8);
+        argb = ('0' + i.toString(16) + '000000');
         a = Math.round(
           el.spectrum('set', argb).spectrum('get').getAlpha() * 255
         );
         if (a != i) {
           return false;
-        };
+        }
       }
       return true;
     })(),

--- a/test/tests.js
+++ b/test/tests.js
@@ -575,6 +575,22 @@ test( "Methods work as described", function() {
   ok (color.toHsvString() == "hsv(39, 100%, 100%)", "Color has been set and gotten as hsv");
   ok (color.toRgbString() == "rgb(255, 165, 0)", "Color has been set and gotten as rgb");
   ok (color.toHslString() == "hsl(39, 100%, 50%)", "Color has been set and gotten as hsl");
+  ok (
+    (function() {
+      var i, argb, a;
+      for (i = 0; i < 16; i++) {
+        argb = ('0' + i.toString(16) + '000000').slice(-8);
+        a = Math.round(
+          el.spectrum('set', argb).spectrum('get').getAlpha() * 255
+        );
+        if (a != i) {
+          return false;
+        };
+      }
+      return true;
+    })(),
+    'Set and get has preserved alpha resolution'
+  );
 
   // Method - container
   ok (el.spectrum("container").hasClass("sp-container"), "Container can be retrieved");


### PR DESCRIPTION
Alpha was rounded to provide a resolution of only 100 gradations, whereas 32-bit color supports 256. Translating from decimal to hex and vice versa made over half of possible alpha values unavailable.