### PR TITLE
pass click event to show.spectrum and beforeShow.spectrum

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -306,7 +306,7 @@
 
             offsetElement.bind("click.spectrum touchstart.spectrum", function (e) {
                 if (!disabled) {
-                    toggle();
+                    toggle(e);
                 }
 
                 e.stopPropagation();
@@ -594,16 +594,16 @@
             }
         }
 
-        function toggle() {
+        function toggle(e) {
             if (visible) {
                 hide();
             }
             else {
-                show();
+                show(e);
             }
         }
 
-        function show() {
+        function show(e) {
             var event = $.Event('beforeShow.spectrum');
 
             if (visible) {
@@ -611,7 +611,7 @@
                 return;
             }
 
-            boundElement.trigger(event, [ get() ]);
+            boundElement.trigger(event, [ get(), e ]);
 
             if (callbacks.beforeShow(get()) === false || event.isDefaultPrevented()) {
                 return;
@@ -633,7 +633,7 @@
 
             drawInitial();
             callbacks.show(colorOnShow);
-            boundElement.trigger('show.spectrum', [ colorOnShow ]);
+            boundElement.trigger('show.spectrum', [ colorOnShow, e ]);
         }
 
         function onkeydown(e) {


### PR DESCRIPTION
I needed to check for ctrl-click and shift-click.
This feature could also be useful to someone else.

Passing forward the click event it is now possibile to check for e.ctrlKey and e.shiftKey with beforeShow.spectrum and show.spectrum.