### PR TITLE
Fixed "onchange" not triggering when clicking inital val

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -882,6 +882,8 @@
                 callbacks.change(color);
                 boundElement.trigger('change', [ color ]);
             }
+            // Since the color in the box has changed, this changes what we think the color is now.
+            colorOnShow = get();
         }
 
         function reflow() {


### PR DESCRIPTION
This has not been fully tested, but this should resolve issues where if you click back on the color that the color picker was when you opened the picker, it would NOT trigger "onchange" without clicking out of it first and reselecting it when another color was chosen.