### PR TITLE
Fix memory leak in a "flat" mode

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -668,13 +668,13 @@
         }
 
         function hide() {
-            // Return if hiding is unnecessary
-            if (!visible || flat) { return; }
-            visible = false;
-
             $(doc).off("keydown.spectrum", onkeydown);
             $(doc).off("click.spectrum", clickout);
             $(window).off("resize.spectrum", resize);
+            
+            // Return if hiding is unnecessary
+            if (!visible || flat) { return; }
+            visible = false;
 
             replacer.removeClass("sp-active");
             container.addClass("sp-hidden");


### PR DESCRIPTION
Event listeners (bound to the document and window) were not cleaned after hiding in a "flat" mode.