### PR TITLE
syntaxis error. extra replace

### DIFF
--- a/i18n/jquery.spectrum-gr.js
+++ b/i18n/jquery.spectrum-gr.js
@@ -13,6 +13,6 @@
         togglePaletteLessText: "Λιγότερα"
     };
 
-    $.extend($.gr.spectrum.defaults, localization);
+    $.extend($.fn.spectrum.defaults, localization);
 
 })( jQuery );


### PR DESCRIPTION
mistake with copy/paste: fix an extra replace to "gr" of "fn" extension method.