### PR TITLE
use allowEmpty at showPaletteOnly

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -137,18 +137,14 @@
             if(current) {
                 var tiny = tinycolor(current);
                 var c = tiny.toHsl().l < 0.5 ? "sp-thumb-el sp-thumb-dark" : "sp-thumb-el sp-thumb-light";
-                c += (tinycolor.equals(color, current)) ? " sp-thumb-active" : "";
+                c += (tinycolor.equals(color, current)) ? " sp-thumb-active" : "";    
                 var formattedString = tiny.toString(opts.preferredFormat || "rgb");
                 var swatchStyle = rgbaSupport ? ("background-color:" + tiny.toRgbString()) : "filter:" + tiny.toFilter();
                 html.push('<span title="' + formattedString + '" data-color="' + tiny.toRgbString() + '" class="' + c + '"><span class="sp-thumb-inner" style="' + swatchStyle + ';" /></span>');
             } else {
-                var cls = 'sp-clear-display';
-                html.push($('<div />')
-                    .append($('<span data-color="" style="background-color:transparent;" class="' + cls + '"></span>')
-                        .attr('title', opts.noColorSelectedText)
-                    )
-                    .html()
-                );
+                var c = 'sp-thumb-el sp-clear-display'
+                var cls = 'sp-clear-palette-only'
+                html.push('<span class="' + c + '" ><span class="' + cls + '" style="background-color: transparent;" /></span>');
             }
         }
         return "<div class='sp-cf " + className + "'>" + html.join('') + "</div>";
@@ -237,7 +233,7 @@
             currentPreferredFormat = opts.preferredFormat,
             clickoutFiresChange = !opts.showButtons || opts.clickoutFiresChange,
             isEmpty = !initialColor,
-            allowEmpty = opts.allowEmpty && !isInputTypeColor;
+            allowEmpty = opts.allowEmpty;
 
         function applyOptions() {
 
@@ -256,6 +252,12 @@
                         var rgb = tinycolor(paletteArray[i][j]).toRgbString();
                         paletteLookup[rgb] = true;
                     }
+                }
+
+                // if showPaletteOnly and didn't set initialcolor
+                // set initialcolor to first palette
+                if (opts.showPaletteOnly && !opts.color) {
+                    initialColor = (palette[0][0] == "") ? palette[0][0] : Object.keys(paletteLookup)[0]
                 }
             }
 
@@ -445,8 +447,10 @@
                 currentPreferredFormat = opts.preferredFormat || tinycolor(initialColor).format;
 
                 addColorToSelectionPalette(initialColor);
-            }
-            else {
+            } else if (initialColor == "") {
+                set(initialColor);
+                updateUI();
+            } else {
                 updateUI();
             }
 
@@ -460,6 +464,7 @@
                     move();
                 }
                 else {
+                    console.log("--------------", $(e.target).closest(".sp-thumb-el").data("color"))
                     set($(e.target).closest(".sp-thumb-el").data("color"));
                     move();
 
@@ -697,7 +702,7 @@
             }
 
             var newColor, newHsv;
-            if (!color && allowEmpty) {
+            if ((!color || color === undefined) && allowEmpty) {
                 isEmpty = true;
             } else {
                 isEmpty = false;


### PR DESCRIPTION
Hi there.

There was solution for this function at #473 , but that was not work for me.
so, I fixed small error about "showPaletteOnly & allowEmpty".

✈️ **HOW TO USE -1**  
This code can use allowEmpty option at "showPaletteOnly : true".  
- set `allowEmpty` to `true`
- Put the `''` at palette where you want it.
```javascript
$("#shadow").spectrum({
        showPaletteOnly: true,
        allowEmpty: true,
        palette: [
            ['', 'black', 'white'],
            ['green', 'blue', 'yellow']
        ]
})
```
✈️ **RESULT**  

![image](https://user-images.githubusercontent.com/40231980/64942264-92763500-d8a3-11e9-98ac-0f9e6987641f.png)


✈️ **HOW TO USE -2**  
it can be used "allowEmpty" option normally.
- set `allowEmpty` to `true`
```javascript
$("#shadow").spectrum({
        allowEmpty: true,
        color: "#ff0000",
})
```

✈️ **RESULT**  

![image](https://user-images.githubusercontent.com/40231980/64942683-a9695700-d8a4-11e9-9856-42e066e029a1.png)
