### PR TITLE
Fix invalid self-closing <span /> tag incompatible with jQuery 3.5

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -140,7 +140,7 @@
                 c += (tinycolor.equals(color, current)) ? " sp-thumb-active" : "";
                 var formattedString = tiny.toString(opts.preferredFormat || "rgb");
                 var swatchStyle = rgbaSupport ? ("background-color:" + tiny.toRgbString()) : "filter:" + tiny.toFilter();
-                html.push('<span title="' + formattedString + '" data-color="' + tiny.toRgbString() + '" class="' + c + '"><span class="sp-thumb-inner" style="' + swatchStyle + ';" /></span>');
+                html.push('<span title="' + formattedString + '" data-color="' + tiny.toRgbString() + '" class="' + c + '"><span class="sp-thumb-inner" style="' + swatchStyle + ';"></span></span>');
             } else {
                 var cls = 'sp-clear-display';
                 html.push($('<div />')


### PR DESCRIPTION
To close a cross-site scripting vulnerability, jQuery 3.5.0 disabled an insecure `htmlPrefilter` that previously fixed up invalid self-closing tags. Fix our HTML not to rely on that.

https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/

Fixes #558.