### PR TITLE
Replace deprecated jQuery methods

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -249,7 +249,7 @@
 
             if (opts.palette) {
                 palette = opts.palette.slice(0);
-                paletteArray = $.isArray(palette[0]) ? palette : [palette];
+                paletteArray = Array.isArray(palette[0]) ? palette : [palette];
                 paletteLookup = {};
                 for (var i = 0; i < paletteArray.length; i++) {
                     for (var j = 0; j < paletteArray[i].length; j++) {
@@ -321,14 +321,14 @@
             }
 
             // Prevent clicks from bubbling up to document.  This would cause it to be hidden.
-            container.click(stopPropagation);
+            container.on("click", stopPropagation);
 
             // Handle user typed input
-            textInput.change(setFromTextInput);
+            textInput.on("change", setFromTextInput);
             textInput.on("paste", function () {
                 setTimeout(setFromTextInput, 1);
             });
-            textInput.keydown(function (e) { if (e.keyCode == 13) { setFromTextInput(); } });
+            textInput.on("keydown", function (e) { if (e.keyCode == 13) { setFromTextInput(); } });
 
             cancelButton.text(opts.cancelText);
             cancelButton.on("click.spectrum", function (e) {


### PR DESCRIPTION
Fixes these warnings from jquery-migrate:

```
JQMIGRATE: jQuery.isArray is deprecated; use Array.isArray
JQMIGRATE: jQuery.fn.click() event shorthand is deprecated
JQMIGRATE: jQuery.fn.change() event shorthand is deprecated
JQMIGRATE: jQuery.fn.keydown() event shorthand is deprecated
```
